### PR TITLE
Wrap inner navbar content in container

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,23 +42,25 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="collapsibleNavbar">
-            <ul class="navbar-nav">
-                {% for item in site.data.sitemap.main %}
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ item.url }}">{{ item.title }}</a>
-                </li>
-                {% endfor %}
-                <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Download</a>
-                    <div class="dropdown-menu">
-                        <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/download/v{{ site.releasetag }}/win-acme.v{{ site.releasebuild }}.x64.trimmed.zip">{{ site.releasename }} <strong>(recommended)</strong></a>
-                        <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/download/v{{ site.releasetag }}/win-acme.v{{ site.releasebuild }}.x64.pluggable.zip">{{ site.releasename }} (larger download, plugin support)</a>
-                        <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/">x86/ARM64 builds</a>
-                        <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/">Release notes</a>
-                        <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/">Older versions</a>
-                    </div>
-                </li>
-            </ul>
+            <div class="container">
+                <ul class="navbar-nav">
+                    {% for item in site.data.sitemap.main %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ item.url }}">{{ item.title }}</a>
+                    </li>
+                    {% endfor %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Download</a>
+                        <div class="dropdown-menu">
+                            <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/download/v{{ site.releasetag }}/win-acme.v{{ site.releasebuild }}.x64.trimmed.zip">{{ site.releasename }} <strong>(recommended)</strong></a>
+                            <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/download/v{{ site.releasetag }}/win-acme.v{{ site.releasebuild }}.x64.pluggable.zip">{{ site.releasename }} (larger download, plugin support)</a>
+                            <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/">x86/ARM64 builds</a>
+                            <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/">Release notes</a>
+                            <a class="dropdown-item" href="https://github.com/win-acme/win-acme/releases/">Older versions</a>
+                        </div>
+                    </li>
+                </ul>
+            </div>
         </div>
     </nav>
 


### PR DESCRIPTION
Wrapping the inner content of the nav bar in a container looks nicer in my opinion.

[Example from Bootstrap](https://getbootstrap.com/docs/4.6/components/navbar/#containers)

![Bildschirmfoto 2022-02-16 um 11 48 22](https://user-images.githubusercontent.com/42373861/154249192-22aba77c-faed-4411-bff6-180183c9f74e.png)
